### PR TITLE
Fix a bug that caused err to be nil when an error occurred

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -321,7 +321,7 @@ func (s *Server) validateServiceAccountRequest(logger *log.Entry, w http.Respons
 
 		w.WriteHeader(http.StatusForbidden)
 		w.Header().Set("Content-Type", "application/json")
-		if err = json.NewEncoder(w).Encode(&ErrorResponse{
+		if err := json.NewEncoder(w).Encode(&ErrorResponse{
 			Error:       "invalid_request",
 			Description: "Service account not enabled on this instance",
 		}); err != nil {


### PR DESCRIPTION
Since it was reusing the existing err var, err was set to nil unless
there was a second error in the json encoding.

This in turn made the function appear to succeed,
but return nil, causing a nil pointer deref down the line.