### PR TITLE
Add "default project" option to make annotations easier for common case

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Usage of ./k8s-gke-service-account-assigner:
       --debug                               Enable debug features
       --default-scopes string               Fallback scopes to use when annotation is not set
       --default-service-account string      Fallback service account to use when annotation is not set
+      --default-project                     Fallback project id to use when service account annotation is given without an associated project id
       --host-interface string               Host interface for proxying google compute engine metadata (default "eth0")
       --host-ip string                      IP address of host
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "accounts.google.com/service-account")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.BoolVar(&s.Verbose, "verbose", false, "Verbose")
 	fs.BoolVar(&s.Version, "version", false, "Print the version and exits")
 	fs.StringVar(&s.DefaultScopes, "default-scopes", s.DefaultScopes, "Fallback scopes to use when annotation is not set")
+	fs.StringVar(&s.DefaultProject, "default-project", s.DefaultProject, "Fallback project id to use when service account annotation is given without an associated project id")
 }
 
 func main() {

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -13,6 +13,7 @@ import (
 type ServiceAccountMapper struct {
 	defaultServiceAccount string
 	defaultScopes         string
+	defaultProject        string
 	iamServiceAccountKey  string
 	iamScopeKey           string
 	namespaceKey          string
@@ -74,6 +75,13 @@ func (r *ServiceAccountMapper) extractServiceAccount(pod *v1.Pod) (string, error
 	if !annotationPresent {
 		log.Warnf("Using fallback service account for IP %s", pod.Status.PodIP)
 		serviceAccount = r.defaultServiceAccount
+	}
+
+	if !strings.Contains(serviceAccount, "@") {
+		if r.defaultProject == "" {
+			return "", fmt.Errorf("Invalid service account for IP %s: Must be of form USER@HOST, eg. NAME@PROJECT_ID.iam.gserviceaccount.com", pod.Status.PodIP)
+		}
+		serviceAccount = fmt.Sprintf("%s@%s.iam.gserviceaccount.com", serviceAccount, r.defaultProject)
 	}
 
 	return serviceAccount, nil
@@ -150,10 +158,11 @@ func (r *ServiceAccountMapper) DumpDebugInfo() map[string]interface{} {
 }
 
 // NewServiceAccountMapper returns a new ServiceAccountMapper for use.
-func NewServiceAccountMapper(serviceAccountKey string, scopeKey string, defaultServiceAccount string, defaultScopes string, namespaceRestriction bool, namespaceKey string, kubeStore store) *ServiceAccountMapper {
+func NewServiceAccountMapper(serviceAccountKey string, scopeKey string, defaultServiceAccount string, defaultScopes string, defaultProject string, namespaceRestriction bool, namespaceKey string, kubeStore store) *ServiceAccountMapper {
 	return &ServiceAccountMapper{
 		defaultServiceAccount: defaultServiceAccount,
 		defaultScopes:         defaultScopes,
+		defaultProject:        defaultProject,
 		iamServiceAccountKey:  serviceAccountKey,
 		iamScopeKey:           scopeKey,
 		namespaceKey:          namespaceKey,

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	IAMScopeKey           string
 	DefaultServiceAccount string
 	DefaultScopes         string
+	DefaultProject        string
 	MetadataAddress       string
 	HostInterface         string
 	HostIP                string
@@ -381,7 +382,7 @@ func (s *Server) Run(host, token, nodeName string, insecure bool) error {
 	}
 	s.k8s = k
 	s.iam = iam.NewClient()
-	s.serviceAccountMapper = mappings.NewServiceAccountMapper(s.IAMServiceAccountKey, s.IAMScopeKey, s.DefaultServiceAccount, s.DefaultScopes, s.NamespaceRestriction, s.NamespaceKey, s.k8s)
+	s.serviceAccountMapper = mappings.NewServiceAccountMapper(s.IAMServiceAccountKey, s.IAMScopeKey, s.DefaultServiceAccount, s.DefaultScopes, s.DefaultProject, s.NamespaceRestriction, s.NamespaceKey, s.k8s)
 	podSynched := s.k8s.WatchForPods(saassigner.NewPodHandler(s.IAMServiceAccountKey))
 	namespaceSynched := s.k8s.WatchForNamespaces(saassigner.NewNamespaceHandler(s.NamespaceKey))
 


### PR DESCRIPTION
This causes ambiguous service account names with no host-part
(eg. "foo", not "foo@PROJECT.iam.gserviceaccount.com") to be automatically
treated as a user-managed account for the given default project.

This is a huge usability gain in the common case,
as it means most users can simply annotate as "foo", instead of "foo@my-project.iam.gserviceaccount.com",
which is especially annoying when the project id may be generated elsewhere.