### PR TITLE
Add globbing support to namespace whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,12 @@ kind: Namespace
 metadata:
   annotations:
     accounts.google.com/allowed-service-accounts: |
-      ["service-account"]
+      ["<PROJECT-ID>-compute@developer.gserviceaccount.com"]
   name: default
 ```
+
+The entries in the array may also be [glob patterns](https://golang.org/pkg/path/filepath/#Match).
+For example, you could match any user-managed service account for a project using `["*@<PROJECT-ID>.iam.gserviceaccount.com"]`.
 
 ### RBAC Setup
 

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -2,6 +2,7 @@ package mappings
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	saassigner "github.com/imduffy15/k8s-gke-service-account-assigner"
@@ -109,7 +110,7 @@ func (r *ServiceAccountMapper) checkServiceAccountForNamespace(serviceAccount st
 
 	ar := saassigner.GetNamespaceServiceAccountAnnotation(ns, r.namespaceKey)
 	for _, serviceAccountPattern := range ar {
-		if serviceAccountPattern == serviceAccount {
+		if match, err := filepath.Match(serviceAccountPattern, serviceAccount); err == nil && match {
 			log.Debugf("Service account: %s matched %s on namespace:%s.", serviceAccount, serviceAccountPattern, namespace)
 			return true
 		}


### PR DESCRIPTION
This is a highly useful feature in kube2iam, for example to allow unrestricted namespaces
(with "*") while still restricting others, or to resitrct namespaces to particular projects,
or for other bespoke naming schemes.