### PR TITLE
readme: Improve docs on what capabilities are strictly required

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ iptables \
 ```
 
 This rule can be added automatically by setting `--iptables=true`, setting the `HOST_IP` environment
-variable, and running the container in a privileged security context.
+variable, and running the container in a privileged security context (or more granularly with `CAP_NET_ADMIN` and `CAP_NET_RAW`).
 
 ### kubernetes annotation
 


### PR DESCRIPTION
This is useful if you're uneasy about running priveliged containers,
and would prefer to restrict them to the minimum required set of capabilities.