### PR TITLE
Improved error messages for failures in ImpersonateServiceAccount

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -46,12 +46,12 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 
 		client, err := google.DefaultClient(ctx, iamcredentials.CloudPlatformScope)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to get google client: %s", err.Error())
 		}
 
 		iamCredentialsClient, err := iamcredentials.New(client)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to get iam credentials client: %s", err.Error())
 		}
 
 		generateAccessTokenResponse, err := iamCredentialsClient.Projects.ServiceAccounts.GenerateAccessToken(
@@ -62,7 +62,7 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 		).Do()
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to generate token: %s", err.Error())
 		}
 
 		return generateAccessTokenResponse, nil
@@ -75,7 +75,7 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 
 	expiresTime, err := time.Parse(time.RFC3339, accessToken.ExpireTime)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse token expiry time %v: %s", accessToken.ExpireTime, err.Error())
 	}
 
 	return &Credentials{


### PR DESCRIPTION
I added this while debugging an issue that turned out to be user error,
but I thought it might be better to have going forward.