### PR TITLE
Add GKE Metadata Concealment support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
   - docker
 
 go:
-  - 1.8.x
+  - 1.11.x
+  - 1.12.x
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,14 @@ check:
 	go install ./cmd
 
 	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=$(METALINTER_DEADLINE)s ./... --vendor --linter='errcheck:errcheck:-ignore=net:Close' --cyclo-over=20 \
-		--linter='vet:govet --no-recurse -composites=false:PATH:LINE:MESSAGE' --disable=interfacer --dupl-threshold=50
+		--linter='vet:govet --no-recurse -composites=false:PATH:LINE:MESSAGE' --disable=interfacer --dupl-threshold=50 \
+		--disable=vetshadow
 
 check-all:
 	go install ./cmd
 	gometalinter --concurrency=$(METALINTER_CONCURRENCY) --deadline=600s ./... --vendor --cyclo-over=20 \
-		--linter='vet:govet --no-recurse:PATH:LINE:MESSAGE' --dupl-threshold=50
-		--dupl-threshold=50
+		--linter='vet:govet --no-recurse:PATH:LINE:MESSAGE' --dupl-threshold=50 \
+		--disable=vetshadow
 
 watch:
 	CompileDaemon -color=true -build "make cross" --exclude-dir=".git" -exclude-dir="vendor"

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Usage of ./k8s-gke-service-account-assigner:
       --debug                               Enable debug features
       --default-scopes string               Fallback scopes to use when annotation is not set
       --default-service-account string      Fallback service account to use when annotation is not set
+      --enable-metadata-proxy               Send traffic to next-hop proxy
       --host-interface string               Host interface for proxying google compute engine metadata (default "eth0")
       --host-ip string                      IP address of host
       --iam-role-key string                 Pod annotation key used to retrieve the IAM role (default "accounts.google.com/service-account")
@@ -225,12 +226,17 @@ Usage of ./k8s-gke-service-account-assigner:
       --log-format string                   Log format (text/json) (default "text")
       --log-level string                    Log level (default "info")
       --metadata-addr string                Address for the google compute engine metadata (default "169.254.169.254")
+      --metadata-proxy-addr string          Address for the next-hop proxy, like GKE metadata concealment proxy (default "127.0.0.1:988")
       --namespace-key string                Namespace annotation key used to retrieve the service accounts allowed (value in annotation should be json array) (default "accounts.google.com/allowed-service-accounts")
       --namespace-restrictions              Enable namespace restrictions
       --node string                         Name of the node where k8s-gke-service-account-assigner is running
       --verbose                             Verbose
       --version                             Print the version and exits
 ```
+
+### Usage with GKE Metadata Concealment
+
+[GKE's Metadata concealment](https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment) protects some potentially sensitive system metadata from user workloads running on your cluster. It does so by deploying [k8s-metadata-proxy](https://github.com/GoogleCloudPlatform/k8s-metadata-proxy) and routing traffic to metadata service via this proxy. K8s-gke-service-account-assigner will take precedence, by putting it's iptables rule before the k8s-metadata-proxy one, and therefore effectively bypassing it. If you want to use both, set `--enable-metadata-proxy`, in which case the traffic will we sent to the `--metadata-proxy-addr` (defaults to `127.0.0.1:988`- GKE's metadata-proxy default location).
 
 ## Development loop
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Usage of ./k8s-gke-service-account-assigner:
       --log-format string                   Log format (text/json) (default "text")
       --log-level string                    Log level (default "info")
       --metadata-addr string                Address for the google compute engine metadata (default "169.254.169.254")
-      --metadata-proxy-addr string          Address for the next-hop proxy, like GKE metadata concealment proxy (default "127.0.0.1:988")
+      --metadata-proxy-addr string          Address for the next-hop proxy, defaults to GKE's metadata-proxy location (default "127.0.0.1:988")
       --namespace-key string                Namespace annotation key used to retrieve the service accounts allowed (value in annotation should be json array) (default "accounts.google.com/allowed-service-accounts")
       --namespace-restrictions              Enable namespace restrictions
       --node string                         Name of the node where k8s-gke-service-account-assigner is running
@@ -236,7 +236,7 @@ Usage of ./k8s-gke-service-account-assigner:
 
 ### Usage with GKE Metadata Concealment
 
-[GKE's Metadata concealment](https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment) protects some potentially sensitive system metadata from user workloads running on your cluster. It does so by deploying [k8s-metadata-proxy](https://github.com/GoogleCloudPlatform/k8s-metadata-proxy) and routing traffic to metadata service via this proxy. K8s-gke-service-account-assigner will take precedence, by putting it's iptables rule before the k8s-metadata-proxy one, and therefore effectively bypassing it. If you want to use both, set `--enable-metadata-proxy`, in which case the traffic will we sent to the `--metadata-proxy-addr` (defaults to `127.0.0.1:988`- GKE's metadata-proxy default location).
+[GKE's Metadata concealment](https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment) protects some potentially sensitive system metadata from user workloads running on your cluster. It does so by deploying [k8s-metadata-proxy](https://github.com/GoogleCloudPlatform/k8s-metadata-proxy) and routing traffic to metadata service via this proxy. K8s-gke-service-account-assigner will take precedence, by putting its iptables rule before the k8s-metadata-proxy one, and therefore effectively bypassing it. If you want to use both, set `--enable-metadata-proxy`, in which case the traffic will we sent to the `--metadata-proxy-addr` (defaults to `127.0.0.1:988`, GKE's metadata-proxy default location).
 
 ## Development loop
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.IAMServiceAccountKey, "iam-role-key", s.IAMServiceAccountKey, "Pod annotation key used to retrieve the IAM role")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the google compute engine metadata")
-	fs.StringVar(&s.MetadataProxyAddress, "metadata-proxy-addr", s.MetadataProxyAddress, "Address for the next-hop proxy, like GKE metadata concealment proxy")
+	fs.StringVar(&s.MetadataProxyAddress, "metadata-proxy-addr", s.MetadataProxyAddress, "Address for the next-hop proxy, defaults to GKE's metadata-proxy location")
 	fs.BoolVar(&s.EnableMetadataProxy, "enable-metadata-proxy", s.Debug, "Send traffic to next-hop proxy")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
 	fs.StringVar(&s.HostInterface, "host-interface", "eth0", "Host interface for proxying google compute engine metadata")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,8 @@ func addFlags(s *server.Server, fs *pflag.FlagSet) {
 	fs.StringVar(&s.IAMServiceAccountKey, "iam-role-key", s.IAMServiceAccountKey, "Pod annotation key used to retrieve the IAM role")
 	fs.BoolVar(&s.Insecure, "insecure", false, "Kubernetes server should be accessed without verifying the TLS. Testing only")
 	fs.StringVar(&s.MetadataAddress, "metadata-addr", s.MetadataAddress, "Address for the google compute engine metadata")
+	fs.StringVar(&s.MetadataProxyAddress, "metadata-proxy-addr", s.MetadataProxyAddress, "Address for the next-hop proxy, like GKE metadata concealment proxy")
+	fs.BoolVar(&s.EnableMetadataProxy, "enable-metadata-proxy", s.Debug, "Send traffic to next-hop proxy")
 	fs.BoolVar(&s.AddIPTablesRule, "iptables", false, "Add iptables rule (also requires --host-ip)")
 	fs.StringVar(&s.HostInterface, "host-interface", "eth0", "Host interface for proxying google compute engine metadata")
 	fs.BoolVar(&s.NamespaceRestriction, "namespace-restrictions", false, "Enable namespace restrictions")

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -46,12 +46,12 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 
 		client, err := google.DefaultClient(ctx, iamcredentials.CloudPlatformScope)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get google client: %s", err.Error())
+			return nil, fmt.Errorf("failed to get google client: %s", err.Error())
 		}
 
 		iamCredentialsClient, err := iamcredentials.New(client)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get iam credentials client: %s", err.Error())
+			return nil, fmt.Errorf("failed to get iam credentials client: %s", err.Error())
 		}
 
 		generateAccessTokenResponse, err := iamCredentialsClient.Projects.ServiceAccounts.GenerateAccessToken(
@@ -62,7 +62,7 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 		).Do()
 
 		if err != nil {
-			return nil, fmt.Errorf("Failed to generate token: %s", err.Error())
+			return nil, fmt.Errorf("failed to generate token: %s", err.Error())
 		}
 
 		return generateAccessTokenResponse, nil
@@ -75,7 +75,7 @@ func (iam *Client) ImpersonateServiceAccount(serviceAccountMappingResult *mappin
 
 	expiresTime, err := time.Parse(time.RFC3339, accessToken.ExpireTime)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse token expiry time %v: %s", accessToken.ExpireTime, err.Error())
+		return nil, fmt.Errorf("failed to parse token expiry time %v: %s", accessToken.ExpireTime, err.Error())
 	}
 
 	return &Credentials{

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -49,10 +49,10 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 		}
 		log.Debugf("Inserting iptables rule at position %d - %s, %s, %s", proxyRuleLine, "nat", "PREROUTING", rulespec)
 		return ipt.Insert("nat", "PREROUTING", proxyRuleLine, rulespec...)
-	} else {
-		log.Debugf("Appending iptables rule %s, %s, %s", "nat", "PREROUTING", rulespec)
-		return ipt.AppendUnique("nat", "PREROUTING", rulespec...)
 	}
+
+	log.Debugf("Appending iptables rule %s, %s, %s", "nat", "PREROUTING", rulespec)
+	return ipt.AppendUnique("nat", "PREROUTING", rulespec...)
 }
 
 // checkInterfaceExists validates the interface passed exists for the given system.

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -2,9 +2,13 @@ package iptables
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
+	log "github.com/sirupsen/logrus"
 )
+
+type myIPTables iptables.IPTables
 
 // AddRule adds the required rule to the host's nat table.
 func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
@@ -22,10 +26,33 @@ func AddRule(appPort, metadataAddress, hostInterface, hostIP string) error {
 		return err
 	}
 
-	return ipt.AppendUnique(
-		"nat", "PREROUTING", "-p", "tcp", "-d", metadataAddress, "--dport", "80",
-		"-j", "DNAT", "--to-destination", hostIP+":"+appPort,
-	)
+	proxyRulePresent, proxyRuleLine, err := (*myIPTables)(ipt).detectConcealmentProxyRule(metadataAddress)
+	if err != nil {
+		return err
+	}
+
+	rulespec := []string{"-p", "tcp", "-d", metadataAddress, "--dport", "80",
+		"-j", "DNAT", "--to-destination", hostIP + ":" + appPort}
+
+	if proxyRulePresent {
+		// if our rule exists, we delete and re-insert to make sure it's at the right place
+		exists, err := ipt.Exists("nat", "PREROUTING", rulespec...)
+		if err != nil {
+			return err
+		}
+		if exists {
+			log.Debugf("Deleting existing iptables rule %s, %s, %s", "nat", "PREROUTING", rulespec)
+			err := ipt.Delete("nat", "PREROUTING", rulespec...)
+			if err != nil {
+				return err
+			}
+		}
+		log.Debugf("Inserting iptables rule at position %d - %s, %s, %s", proxyRuleLine, "nat", "PREROUTING", rulespec)
+		return ipt.Insert("nat", "PREROUTING", proxyRuleLine, rulespec...)
+	} else {
+		log.Debugf("Appending iptables rule %s, %s, %s", "nat", "PREROUTING", rulespec)
+		return ipt.AppendUnique("nat", "PREROUTING", rulespec...)
+	}
 }
 
 // checkInterfaceExists validates the interface passed exists for the given system.
@@ -39,4 +66,22 @@ func checkInterfaceExists(hostInterface string) error {
 
 	// _, err := net.InterfaceByName(hostInterface)
 	// return err
+}
+
+// detect if GKE Metadata Concealment rule is present
+func (ipt *myIPTables) detectConcealmentProxyRule(metadataAddress string) (bool, int, error) {
+
+	rules, err := (*iptables.IPTables)(ipt).List("nat", "PREROUTING")
+	if err != nil {
+		return false, 0, err
+	}
+
+	for i, rule := range rules {
+		if strings.Contains(rule, "-A PREROUTING -d "+metadataAddress+"/32 -p tcp -m tcp --dport 80") {
+			log.Debugf("Found existing metadata proxy rule %s", rule)
+			return true, i, nil
+		}
+	}
+
+	return false, 0, nil
 }

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -77,7 +77,9 @@ func (ipt *myIPTables) detectConcealmentProxyRule(metadataAddress string) (bool,
 	}
 
 	for i, rule := range rules {
-		if strings.Contains(rule, "-A PREROUTING -d "+metadataAddress+"/32 -p tcp -m tcp --dport 80") {
+		if strings.Contains(rule, "-A PREROUTING") &&
+			strings.Contains(rule, "-d "+metadataAddress+"/32") &&
+			strings.Contains(rule, "-m tcp --dport 80") {
 			log.Debugf("Found existing metadata proxy rule %s", rule)
 			return true, i, nil
 		}

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -93,7 +93,7 @@ func (k8s *Client) PodByIP(IP string) (*v1.Pod, error) {
 	}
 
 	if len(pods) == 0 {
-		return nil, fmt.Errorf("Pod with specificed IP not found")
+		return nil, fmt.Errorf("pod with specificed IP not found")
 	}
 
 	if len(pods) == 1 {
@@ -117,7 +117,7 @@ func (k8s *Client) NamespaceByName(namespaceName string) (*v1.Namespace, error) 
 	}
 
 	if len(namespace) == 0 {
-		return nil, fmt.Errorf("Namespace was not found")
+		return nil, fmt.Errorf("namespace was not found")
 	}
 
 	return namespace[0].(*v1.Namespace), nil

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -59,7 +59,7 @@ func (r *ServiceAccountMapper) GetServiceAccountMapping(IP string) (*ServiceAcco
 		return &ServiceAccountMappingResult{ServiceAccount: serviceAccount, Scopes: scopes, Namespace: pod.GetNamespace(), IP: IP}, nil
 	}
 
-	return nil, fmt.Errorf("Service Account requested %s not valid for namespace of pod at %s with namespace %s", serviceAccount, IP, pod.GetNamespace())
+	return nil, fmt.Errorf("service account requested %s not valid for namespace of pod at %s with namespace %s", serviceAccount, IP, pod.GetNamespace())
 }
 
 // extractQualifiedRoleName extracts a fully qualified ARN for a given pod,
@@ -69,7 +69,7 @@ func (r *ServiceAccountMapper) extractServiceAccount(pod *v1.Pod) (string, error
 	serviceAccount, annotationPresent := pod.GetAnnotations()[r.iamServiceAccountKey]
 
 	if !annotationPresent && r.defaultServiceAccount == "" {
-		return "", fmt.Errorf("Unable to find service account for IP %s", pod.Status.PodIP)
+		return "", fmt.Errorf("unable to find service account for IP %s", pod.Status.PodIP)
 	}
 
 	if !annotationPresent {
@@ -84,7 +84,7 @@ func (r *ServiceAccountMapper) extractScopes(pod *v1.Pod) ([]string, error) {
 	scopes, annotationPresent := pod.GetAnnotations()[r.iamScopeKey]
 
 	if !annotationPresent && r.defaultScopes == "" {
-		return nil, fmt.Errorf("Unable to find scopes for IP %s", pod.Status.PodIP)
+		return nil, fmt.Errorf("unable to find scopes for IP %s", pod.Status.PodIP)
 	}
 
 	if !annotationPresent {

--- a/mappings/mapper.go
+++ b/mappings/mapper.go
@@ -104,7 +104,7 @@ func (r *ServiceAccountMapper) checkServiceAccountForNamespace(serviceAccount st
 
 	ns, err := r.store.NamespaceByName(namespace)
 	if err != nil {
-		log.Debug("Unable to find an indexed namespace of %s", namespace)
+		log.Debugf("Unable to find an indexed namespace of %s", namespace)
 		return false
 	}
 

--- a/namespace.go
+++ b/namespace.go
@@ -81,7 +81,7 @@ func GetNamespaceServiceAccountAnnotation(ns *v1.Namespace, namespaceKey string)
 func NamespaceIndexFunc(obj interface{}) ([]string, error) {
 	namespace, ok := obj.(*v1.Namespace)
 	if !ok {
-		return nil, fmt.Errorf("Expected namespace but recieved: %+v", obj)
+		return nil, fmt.Errorf("expected namespace but recieved: %+v", obj)
 	}
 
 	return []string{namespace.GetName()}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -51,7 +51,6 @@ type Server struct {
 	DefaultScopes         string
 	MetadataAddress       string
 	MetadataProxyAddress  string
-	EnableMetadataProxy   bool
 	HostInterface         string
 	HostIP                string
 	NodeName              string
@@ -60,6 +59,7 @@ type Server struct {
 	LogFormat             string
 	AddIPTablesRule       bool
 	Debug                 bool
+	EnableMetadataProxy   bool
 	Insecure              bool
 	NamespaceRestriction  bool
 	Verbose               bool
@@ -105,7 +105,7 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			case error:
 				err = t
 			default:
-				err = errors.New("Unknown error")
+				err = errors.New("unknown error")
 			}
 			logger.WithField("res.status", http.StatusInternalServerError).
 				Errorf("PANIC error processing request: %+v", err)
@@ -360,7 +360,7 @@ func (s *Server) validateServiceAccountRequest(logger *log.Entry, w http.Respons
 			logger.Errorf("Error sending json %+v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		return nil, fmt.Errorf("Invalid service account (%s): does not match annotated service account (%s)", wantedServiceAccount, serviceAccountMapping.ServiceAccount)
+		return nil, fmt.Errorf("invalid service account (%s): does not match annotated service account (%s)", wantedServiceAccount, serviceAccountMapping.ServiceAccount)
 	}
 
 	return serviceAccountMapping, nil


### PR DESCRIPTION
This PR adds support for k8s-gke-service-account-assigner to work with GKE Metadata concealment is enabled (https://cloud.google.com/kubernetes-engine/docs/how-to/protecting-cluster-metadata#concealment). At the moment k8s-gke-service-account-assigner does not work, as the existing iptables rule always takes precedence before the one inserted.

Addresses #7

Changes introduced:
- Detect existing iptables rule and insert itself before
- Add support for "next-hop" proxy
- Add docs on how to use with GKE Metadata concealment enabled
- Bumps go version in Travis to 1.11 & 1.12 (1.8 does not support type aliases)
- Fixes few minor errors that were failing with newer go version
- Fix various gometalinter warnings and errors
- Disables go vet shadow to pass on 1.11 (the `warning: declaration of "err" shadows declaration` seem like false positives to me)

Tests done:
- Verified that k8s-gke-service-account-assigner works (both with and without `--enable-metadata-proxy`)
- Verified that with `--enable-metadata-proxy` the Metadata concealment is in place
  ```console
  $ curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env" -H "Metadata-Flavor: Google"
  This metadata endpoint is concealed.
  ```
- IPtables look as expected
  First rule is by k8s-gke-service-account-assigner, second by GKE metadata-proxy
  ```console
  $ iptables -S PREROUTING -t nat
  -P PREROUTING ACCEPT
  -A PREROUTING -m comment --comment "cali:6gwbT8clXdHdC1b1" -j cali-PREROUTING
  -A PREROUTING -m addrtype --dst-type LOCAL -j CNI-HOSTPORT-DNAT
  -A PREROUTING -m comment --comment "kubernetes service portals" -j KUBE-SERVICES
  -A PREROUTING -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.16.0.6:8181
  -A PREROUTING -d 169.254.169.254/32 -p tcp -m tcp --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 127.0.0.1:988
  ```