### PR TITLE
Make recursion query string case insensitive

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -300,7 +300,7 @@ func (s *Server) serviceAccountHandler(logger *log.Entry, w http.ResponseWriter,
 
 		recursive := r.URL.Query().Get("recursive")
 
-		if recursive != "True" {
+		if !strings.EqualFold(recursive, "True") {
 			for _, path := range []string{"aliases", "email", "identity", "scopes", "token"} {
 				write(logger, w, fmt.Sprintf("%s\n", path))
 			}


### PR DESCRIPTION
The python google client was making requests with the recursive query
parameter set to the lowercase "true"

DEBUG:google.auth.transport.requests:Making request: GET
http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/?recursive=true

which caused the storage request to fail with;

File "/usr/local/lib/python3.7/site-packages/google/auth/compute_engine/credentials.py", line 80, in _retrieve_info
    self._service_account_email = info['email']
TypeError: string indices must be integers